### PR TITLE
Add link to Finding data

### DIFF
--- a/docs/cmsOpenData/findingData.md
+++ b/docs/cmsOpenData/findingData.md
@@ -1,4 +1,4 @@
 # Finding Data
 
-!!! Warning
-    This page is under construction
+All CMS open data are available through [the CERN Open Data portal](http://opendata.cern.ch/).
+See the CMS Open data Workshop [tutorial lesson](https://cms-opendata-workshop.github.io/workshop2022-lesson-dataset-scouting/) for advice on how to explore available CMS datasets on the CERN Open Data portal.


### PR DESCRIPTION
Add a link to the tutorial lesson as a first aid. To do later: the reference material should be brought to the guide